### PR TITLE
xmr-stak updated to 2.5.2

### DIFF
--- a/nvOC_miner_update.sh
+++ b/nvOC_miner_update.sh
@@ -112,9 +112,9 @@ XMR_Stak_ver_8="2.4.4"
 XMR_Stak_compiled_tarball_ver_8="xmr-stak-2.4.4.tar.xz"
 XMR_Stak_src_hash_ver_8="c0ab1734332d6472225d8ac7394f6fcba71aabc9"
 
-XMR_Stak_ver_9="2.5.1"
-XMR_Stak_compiled_tarball_ver_9="xmr-stak-2.5.1.tar.xz"
-XMR_Stak_src_hash_ver_9="4e72408ff96003995af73b55bbb271f9984ca3d3"
+XMR_Stak_ver_9="2.5.2"
+XMR_Stak_compiled_tarball_ver_9="xmr-stak-2.5.2.tar.xz"
+XMR_Stak_src_hash_ver_9="752fd1e7e228cc488d77d771b4615a8eb9fa9c86"
 
 ZENEMYminer_ver_8="1.10"
 ZENEMYminer_compiled_tarball_ver_8="z-enemy-1.10-cuda80.tar.xz"
@@ -605,7 +605,7 @@ function compile-XMR_Stak {
   mkdir ${NVOC_MINERS}/XMR_Stak/src/build
   pushd ${NVOC_MINERS}/XMR_Stak/src/build
   cmake ..
-  make install
+  make
   popd
   stop-if-needed "[xmr]-stak"
   cp ${NVOC_MINERS}/XMR_Stak/src/build/bin/xmr-stak ${NVOC_MINERS}/XMR_Stak/src/build/bin/*.so ${NVOC_MINERS}/XMR_Stak/


### PR DESCRIPTION
Compiled with cuda 9, includes config.txt and pools.txt templates.

Closes #25 