### PR TITLE
Fixing xmrstak

### DIFF
--- a/XMR_Stak/2.4.4/.nvoc-miner.json
+++ b/XMR_Stak/2.4.4/.nvoc-miner.json
@@ -1,8 +1,16 @@
 {
   "friendlyname": "XMR-Stak Cryptonight",
   "version": "2.4.4",
-  "hcd": "xmr-stak.nvoc.sh --config \"${mpath}/${!xversion}/config.txt\" --poolconf \"${mpath}/${!xversion}/pools.txt\" --nvidia \"${mpath}/${!xversion}/nvidia.txt\" --currency monero7 --noCPU --noAMD -o \"${!xpool}\":\"${!xport}\" -u \"${!xaddr}\"\"${!xwallet}\"\"${!xwork}\" -p \"$MINER_PWD\" -i 0",
-  "devlist_format": 0,
+  "hcd": "xmr-stak.nvoc.sh --config \"${mpath}/${!xversion}/config.txt\" --nvidia \"${mpath}/${!xversion}/nvidia.txt\" --currency monero7 --noCPU --noAMD -o \"${!xpool}\":\"${!xport}\" -u \"${!xaddr}\"\"${!xwallet}\"\"${!xwork}\" -p \"$MINER_PWD\" -r \"${!xwork}\" -i 0",
+  "devlist_argument": "",
+  "devlist_separator": "",
+  "devlist_format": "",
+
+  "foreman":
+  {
+    "name": "xmrstak",
+    "api_ext": "--httpd 3333"
+  },
 
   "minerinfo":
   {

--- a/XMR_Stak/2.8.3/.nvoc-miner.json
+++ b/XMR_Stak/2.8.3/.nvoc-miner.json
@@ -1,7 +1,7 @@
 {
   "friendlyname": "XMR-Stak Cryptonight",
   "version": "2.8.3",
-  "hcd": "xmr-stak.nvoc.sh --config \"${mpath}/${!xversion}/config.txt\" --poolconf \"${mpath}/${!xversion}/pools.txt\" --nvidia \"${mpath}/${!xversion}/nvidia.txt\" --currency monero --noCPU --noAMD -o \"${!xpool}\":\"${!xport}\" -u \"${!xaddr}\"\"${!xwallet}\"\"${!xwork}\" -p \"$MINER_PWD\" -i 0",
+  "hcd": "xmr-stak.nvoc.sh --config \"${mpath}/${!xversion}/config.txt\" --nvidia \"${mpath}/${!xversion}/nvidia.txt\" --currency monero --noCPU -o \"${!xpool}\":\"${!xport}\" -u \"${!xaddr}\"\"${!xwallet}\"\"${!xwork}\" -p \"$MINER_PWD\" -r \"${!xwork}\" -i 0",
   "devlist_argument": "",
   "devlist_separator": "",
   "devlist_format": "",


### PR DESCRIPTION
Missing rig name.  That's why the command line wasn't running xmrstak.

Removed "--noAMD" (no longer needed).  Also fixed the 2.4.4 pm.